### PR TITLE
Demo DynamoDB `$context.result` missing `items`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/devcontainers/python:0-3.11
+
+RUN apt-get update && apt-get -y install socat

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+	"name": "LocalStack AppSync/GraphQL playground",
+  "workspaceFolder": "/workspace",
+	"dockerComposeFile": ["docker-compose.yml"],
+  "service": "dev",
+	"features": {
+    "ghcr.io/devcontainers/features/aws-cli:1": {},
+		"ghcr.io/devcontainers/features/node:1": {},
+    "docker-from-docker": "latest"
+	}
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+
+services:
+  dev:
+    build:
+      dockerfile: Dockerfile
+    deploy:
+      resources:
+        limits:
+          memory: '2048M'
+    volumes:
+      - ~/.aws:/home/node/.aws
+    links:
+      - localstack
+    command: socat tcp-listen:4566,reuseaddr,fork tcp:localstack:4566
+
+  localstack:
+    image: localstack/localstack:latest
+    environment:
+      - PERSISTENCE=1
+      - DEBUG=1
+      - LOCALSTACK_API_KEY=
+    expose:
+      - "4566"
+    deploy:
+      resources:
+        limits:
+          memory: '1048M'

--- a/appsync-graphql-api/run.sh
+++ b/appsync-graphql-api/run.sh
@@ -9,15 +9,16 @@ api_id=$(awslocal appsync list-graphql-apis | jq -r '(.graphqlApis[] | select(.n
 echo "DEBUG: api_id is: $api_id" && \
 api_key=$(awslocal appsync create-api-key --api-id $api_id | jq -r .apiKey.id) && \
 echo "DEBUG: api_key is: $api_key" && \
-echo "Starting a WebSocket client to subscribe to GraphQL mutation operations." && \
-source .venv/bin/activate && \
-(python websocket_client.py "$api_id" &) && sleep 2 && \
+# echo "Starting a WebSocket client to subscribe to GraphQL mutation operations." && \
+# source .venv/bin/activate && \
+# (python websocket_client.py "$api_id" &) && sleep 2 && \
 echo "Now trying to invoke the AppSync API for DynamoDB integration under $APPSYNC_URL/$api_id." && \
-curl -H "Content-Type: application/json" -H "x-api-key: $api_key" -d '{"query":"mutation {addPostDDB(id: \"id123\"){id}}"}' $APPSYNC_URL/$api_id && \
-curl -H "Content-Type: application/json" -H "x-api-key: $api_key" -d '{"query":"query {getPostsDDB{id}}"}' $APPSYNC_URL/$api_id && \
-echo "Scanning items from DynamoDB table - should include entry with 'id123':" && \
-awslocal dynamodb scan --table-name table1 && \
-echo "Now trying to invoke the AppSync API for RDS integration." && \
-curl -H "Content-Type: application/json" -H "x-api-key: $api_key" -d '{"query":"mutation {addPostRDS(id: \"id123\"){id}}"}' $APPSYNC_URL/$api_id && \
-curl -H "Content-Type: application/json" -H "x-api-key: $api_key" -d '{"query":"query {getPostsRDS{id}}"}' $APPSYNC_URL/$api_id
+curl -H "Content-Type: application/json" -H "x-api-key: $api_key" -d '{"query":"mutation {addPostDDB(id: \"id-123\"){id}}"}' $APPSYNC_URL/$api_id && \
+curl -H "Content-Type: application/json" -H "x-api-key: $api_key" -d '{"query":"mutation {addPostDDB(id: \"id-abc\"){id}}"}' $APPSYNC_URL/$api_id && \
+curl -H "Content-Type: application/json" -H "x-api-key: $api_key" -d '{"query":"query {getPostsDDB{id}}"}' $APPSYNC_URL/$api_id
 
+echo -e "\n"
+echo "************************************************"
+echo "* Logs for data returned from \$context.result  *"
+echo "************************************************"
+docker logs $(docker ps -q --filter name=localstack-pro-samples_devcontainer-localstack-1) | tail -n 2 | head -n 1


### PR DESCRIPTION
The [AWS docs](https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-dynamodb.html#query-list) state that results returned by DynamoDB should be available under `$context.result.items`. Results appear to be directly under `$context.result`

Steps to observe:

1. Clone repo in to a remote container volume using VSCode
2. Add your `LOCALSTACK_API_KEY` to `.devcontainer/docker-compose.yml`
3. Use VScode to rebuild the container and use the `LOCALSTACK_API_KEY`
4. `cd appsync-graphql-api`
5. `make install`
6. `make run`
7. Observe console output showing the data that was used to render the the response.

The above steps result in a query being made to DynamoDB for which `./appsync-graphql-api/templates/ddb.Scan.response.vlt` is used to render the results as JSON. It uses `$context.result` not `$context.result.items` the content of which can be seen in the localstack container logs, which `make run` prints out.